### PR TITLE
Correct memory issue

### DIFF
--- a/sysctl/_sysctl.c
+++ b/sysctl/_sysctl.c
@@ -218,7 +218,9 @@ static int Sysctl_setvalue(Sysctl *self, PyObject *value, void *closure) {
 			free(oid);
 			return -1;
 		}
-		free(newval);
+		if(self->type != CTLTYPE_STRING) {
+			free(newval);
+		}
 		free(oid);
 	}
 


### PR DESCRIPTION
This commit fixes a bug where we ran into segmentation fault as we tried to free memory which was being taken care of by python's garbage collector.